### PR TITLE
Fix bounds on table to make it threadsafe

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -271,6 +271,6 @@ impl <K, V> Drop for Table<K, V> {
     }
 }
 
-unsafe impl <K, V> Sync for Table<K, V> { }
+unsafe impl <K, V> Sync for Table<K, V> where K: Send + Sync, V: Send + Sync { }
 
-unsafe impl <K, V> Send for Table<K, V> { }
+unsafe impl <K, V> Send for Table<K, V> where K: Send, V: Send { }


### PR DESCRIPTION
To be clear on why I believe this is necessary: you call a hash() method on each key (which might modify it, if it has interior mutability) without taking a lock (I believe) so your keys must be `Sync` for your type to be shared across threads; your iteration method returns & references to K and V so your values must be `Sync` as well.  You can move types from one thread to another through an & reference, hence requiring `Send` for `Sync`.  The `T: Send` requirement is almost a given for any generic using `T` to be `Send`.

This is now the third project of three concurrent data structures I've seen that didn't realize this was necessary, so I'm worried that our documentation on this isn't very good :(  Can you propose any fixes that would make it clearer that you really, absolutely nearly always want to have bounds like this?
