### PR TITLE
Use rw spinlock to protect tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Viktor Dahl <pazaconyoman@gmail.com>"]
 
 [dependencies]
 num = '*'
+spin = '0.3'
 
 [dev-dependencies]
 rand = '*'

--- a/benches/single_threaded.rs
+++ b/benches/single_threaded.rs
@@ -1,5 +1,7 @@
 #![feature(test)]
 #![feature(std_misc)]
+#![feature(hashmap_hasher)]
+
 
 extern crate rand;
 extern crate test;
@@ -10,14 +12,15 @@ use std::cmp::max;
 use test::Bencher;
 use rand::{Rng, weak_rng};
 use concurrent_hashmap::*;
+use std::collections::HashMap;
 
 const INTEGERS: u32 = 100_000;
 
 macro_rules! new_map (
     ($typ: ty) => ({
         let mut options: Options<::std::collections::hash_map::RandomState> = Default::default();
-        options.concurrency = 1;
-        ConcHashMap::<$typ, i8, _>::with_options(options)
+        options.concurrency = 4;
+        ConcHashMap::<$typ, usize, _>::with_options(options)
     })
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
-#![feature(std_misc)]
 #![feature(alloc)]
+#![feature(hashmap_hasher)]
+#![feature(heap_api)]
+#![feature(oom)]
 
 extern crate alloc;
 extern crate num;
+extern crate spin;
 
 mod table;
 mod map;

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,5 @@
 use std::hash::{Hash};
-use std::sync::{RwLockReadGuard};
+use spin::{RwLockReadGuard};
 use std::ptr;
 use std::mem;
 use std::cmp::{max};


### PR DESCRIPTION
This allows higher concurrency and smaller overhead compared to stdlib HashMap on low concurrency, specially on read heavy workloads. 

I also updated the tests/examples to compile in a more recent rustc.
