### PR TITLE
Add mutable find function

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -242,6 +242,8 @@ mod test {
     use std::hash::{BuildHasher, Hasher, BuildHasherDefault};
     use std::default::Default;
     use std::fmt::Debug;
+    use std::thread;
+    use std::sync::Arc;
     use super::*;
 
     struct BadHasher;
@@ -437,6 +439,46 @@ mod test {
         let map: ConcHashMap<u32, u32> = vec.iter().map(|x| *x).collect();
         for &(k, v) in vec.iter() {
             find_assert(&map, &k, &v);
+        }
+    }
+
+    #[test]
+    fn mut_modify() {
+        let map: ConcHashMap<u32, u32> = Default::default();
+        map.insert(1, 0);
+        let mut e = map.find_mut(&1).unwrap().get();
+        *e += 1;
+        assert_eq!(&1, map.find(&1).unwrap().get());
+    }
+
+    #[test]
+    fn conc_mut_modify() {
+        let mmap: Arc<ConcHashMap<u32, u32>> = Arc::new(Default::default());
+        let map = mmap.clone();
+        let range = 10000;
+        for i in 0..range {
+            map.insert(i, i*i);
+        }
+
+        let tl_map = mmap.clone();
+        let reader = thread::spawn(move || {
+            for i in 0..range {
+                tl_map.find(&i).unwrap().get();
+            }
+        });
+
+        let tl_map = mmap.clone();
+        let writer = thread::spawn(move || {
+            for i in 0..range {
+                let mut e = tl_map.find_mut(&i).unwrap().get();
+                *e += 1;
+            }
+        });
+
+        reader.join().unwrap();
+        writer.join().unwrap();
+        for i in 0..range {
+            assert_eq!(map.find(&i).unwrap().get(), &(i*i+1));
         }
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,5 @@
 use std::hash::{Hash};
-use spin::{RwLockReadGuard};
+use spin::{RwLockReadGuard, RwLockWriteGuard};
 use std::ptr;
 use std::mem;
 use std::cmp::{max};
@@ -75,6 +75,11 @@ pub struct Accessor<'a, K: 'a, V: 'a> {
     idx: usize
 }
 
+pub struct MutAccessor<'a, K: 'a, V: 'a> {
+    table: RwLockWriteGuard<'a, Table<K, V>>,
+    idx: usize
+}
+
 impl <'a, K, V> Accessor<'a, K, V> {
     pub fn new(table: RwLockReadGuard<'a, Table<K, V>>, idx: usize) -> Accessor<'a, K, V> {
         Accessor {
@@ -87,6 +92,22 @@ impl <'a, K, V> Accessor<'a, K, V> {
         debug_assert!(self.table.is_present(self.idx));
         unsafe {
             &*self.table.values.offset(self.idx as isize)
+        }
+    }
+}
+
+impl <'a, K, V> MutAccessor<'a, K, V> {
+    pub fn new(table: RwLockWriteGuard<'a, Table<K, V>>, idx: usize) -> MutAccessor<'a, K, V> {
+        MutAccessor {
+            table: table,
+            idx: idx
+        }
+    }
+
+    pub fn get(&mut self) -> &'a mut V {
+        debug_assert!(self.table.is_present(self.idx));
+        unsafe {
+            &mut *self.table.values.offset(self.idx as isize)
         }
     }
 }


### PR DESCRIPTION
This adds a mutable find function to the hashmap as well as a mutable Accessor struct. I've included basic testing of this to make sure that it works, but I'm unsure that it's completely free from data races.
