### PR TITLE
Adding a remove method on the MutAccessor

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -522,6 +522,18 @@ mod test {
     }
 
     #[test]
+    fn test_remove_mut_accessor() {
+        let map: ConcHashMap<i32, String> = Default::default();
+        map.insert(1, "one".to_string());
+        map.insert(2, "two".to_string());
+        map.insert(3, "three".to_string());
+        assert_eq!(Some("two".to_string()), map.find_mut(&2).unwrap().remove());
+        assert_eq!("one", map.find(&1).unwrap().get());
+        assert!(map.find(&2).is_none());
+        assert_eq!("three", map.find(&3).unwrap().get());
+    }
+
+    #[test]
     fn test_from_iterator() {
         let vec: Vec<(u32, u32)> = (0..100).map(|i| (i, i * i)).collect();
         let map: ConcHashMap<u32, u32> = vec.iter().map(|x| *x).collect();

--- a/src/table.rs
+++ b/src/table.rs
@@ -87,7 +87,7 @@ impl <'a, K, V> Accessor<'a, K, V> {
     }
 }
 
-impl <'a, K, V> MutAccessor<'a, K, V> {
+impl <'a, K: Hash + Eq, V> MutAccessor<'a, K, V> {
     pub fn new(table: MutexGuard<'a, Table<K, V>>, idx: usize) -> MutAccessor<'a, K, V> {
         MutAccessor {
             table: table,
@@ -100,6 +100,10 @@ impl <'a, K, V> MutAccessor<'a, K, V> {
         unsafe {
             &mut *self.table.values.offset(self.idx as isize)
         }
+    }
+
+    pub fn remove(&mut self) {
+        self.table.remove_index(self.idx);
     }
 }
 
@@ -171,6 +175,10 @@ impl <K, V> Table<K, V> where K: Hash + Eq {
             Some(i) => i,
             None    => return None
         };
+        self.remove_index(i)
+    }
+
+    pub fn remove_index(&mut self, i: usize) -> Option<V> {
         unsafe {
             drop_in_place::<K>(self.keys.offset(i as isize));
             *self.hashes.offset(i as isize) = TOMBSTONE;

--- a/src/table.rs
+++ b/src/table.rs
@@ -102,8 +102,8 @@ impl <'a, K: Hash + Eq, V> MutAccessor<'a, K, V> {
         }
     }
 
-    pub fn remove(&mut self) {
-        self.table.remove_index(self.idx);
+    pub fn remove(&mut self) -> Option<V> {
+        self.table.remove_index(self.idx)
     }
 }
 


### PR DESCRIPTION
This pull-request is use to improve the usability of MutAccessor by providing the remove method on it.